### PR TITLE
fix: add endpoint to get team by id

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -44,6 +44,14 @@ app.get('/teams', (ctx) => {
   return ctx.json(teams)
 })
 
+app.get('/teams/:id', (ctx) => {
+  const id = ctx.req.param('id')
+  const foundTeam = teams.find((team) => team.id === id)
+  return foundTeam
+    ? ctx.json(foundTeam)
+    : ctx.json({ message: 'Team not found' }, 404)
+})
+
 app.get('/static/*', serveStatic({ root: './' }))
 
 export default app


### PR DESCRIPTION
Add  GET `/team/:id` to get the team info by "id"  (using formatter)