### PR TITLE
add possible parameters in routes of teams and presidents

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -21,7 +21,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'id',
-					route: '/teams/{id}'
+					route: '/teams/{id}',
+					description: 'Returns Kings League team per param id'
 				}
 			]
 		},
@@ -31,7 +32,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'id',
-					route: '/presidents/{id}'
+					route: '/presidents/{id}',
+					description: 'Returns Kings League president of team per param id'
 				}
 			]
 		},

--- a/api/index.js
+++ b/api/index.js
@@ -17,11 +17,23 @@ app.get('/', (ctx) =>
 		},
 		{
 			endpoint: '/teams',
-			description: 'Returns Kings League teams'
+			description: 'Returns Kings League teams',
+			parameters: [
+				{
+					name: 'id',
+					route: '/teams/{id}'
+				}
+			]
 		},
 		{
 			endpoint: '/presidents',
-			description: 'Returns Kings League presidents'
+			description: 'Returns Kings League presidents',
+			parameters: [
+				{
+					name: 'id',
+					route: '/presidents/{id}'
+				}
+			]
 		},
 		{
 			endpoint: '/coachs',

--- a/api/index.js
+++ b/api/index.js
@@ -3,43 +3,43 @@ import { serveStatic } from 'hono/serve-static.module'
 import leaderboard from '../db/leaderboard.json'
 import teams from '../db/teams.json'
 import presidents from '../db/presidents.json'
-import coachs from '../db/coachs.json'
+import coaches from '../db/coaches.json'
 import top_scorer from '../db/top_scorer.json'
 import mvp from '../db/mvp.json'
 
 const app = new Hono()
 
 app.get('/', (ctx) =>
-  ctx.json([
-    {
-      endpoint: '/leaderboard',
-      description: 'Returns Kings League leaderboard'
-    },
-    {
-      endpoint: '/teams',
-      description: 'Returns Kings League teams'
-    },
-    {
-      endpoint: '/presidents',
-      description: 'Returns Kings League presidents'
-    },
-    {
-      endpoint: '/coachs',
-      description: 'Returns Kings League coachs'
-    }
-  ])
+	ctx.json([
+		{
+			endpoint: '/leaderboard',
+			description: 'Returns Kings League leaderboard'
+		},
+		{
+			endpoint: '/teams',
+			description: 'Returns Kings League teams'
+		},
+		{
+			endpoint: '/presidents',
+			description: 'Returns Kings League presidents'
+		},
+		{
+			endpoint: '/coachs',
+			description: 'Returns Kings League coachs'
+		}
+	])
 )
 
 app.get('/leaderboard', (ctx) => {
-  return ctx.json(leaderboard)
+	return ctx.json(leaderboard)
 })
 
 app.get('/presidents', (ctx) => {
-  return ctx.json(presidents)
+	return ctx.json(presidents)
 })
 
 app.get('/coachs\\/?', (ctx) => {
-  return ctx.json(coachs)
+	return ctx.json(coaches)
 })
 
 app.get('/top-scorer', (ctx) => {
@@ -51,33 +51,31 @@ app.get('/mvp', (ctx) => {
 })
 
 app.get('/presidents/:id', (ctx) => {
-  const id = ctx.req.param('id')
-  const foundPresident = presidents.find((president) => president.id === id)
+	const id = ctx.req.param('id')
+	const foundPresident = presidents.find((president) => president.id === id)
 
-  return foundPresident
-    ? ctx.json(foundPresident)
-    : ctx.json({ message: 'President not found' }, 404)
+	return foundPresident
+		? ctx.json(foundPresident)
+		: ctx.json({ message: 'President not found' }, 404)
 })
 
 app.get('/teams/:id', (ctx) => {
-  const id = ctx.req.param('id')
-  const foundTeam = teams.find((team) => team.id === id)
+	const id = ctx.req.param('id')
+	const foundTeam = teams.find((team) => team.id === id)
 
-  return foundTeam
-    ? ctx.json(foundTeam)
-    : ctx.json({ message: 'Team not found' }, 404)
+	return foundTeam ? ctx.json(foundTeam) : ctx.json({ message: 'Team not found' }, 404)
 })
 
 app.get('/static/*', serveStatic({ root: './' }))
 
 app.notFound((c) => {
-  const { pathname } = new URL(c.req.url)
+	const { pathname } = new URL(c.req.url)
 
-  if (c.req.url.at(-1) === '/') {
-    return c.redirect(pathname.slice(0, -1))
-  }
+	if (c.req.url.at(-1) === '/') {
+		return c.redirect(pathname.slice(0, -1))
+	}
 
-  return c.json({ message: 'Not Found' }, 404)
+	return c.json({ message: 'Not Found' }, 404)
 })
 
 export default app


### PR DESCRIPTION
Añado en la rutas inicial de información, las especificaciones de las rutas donde puede recibir paramentos como /teams/:id o /presidents/:id
 
El commit [change import of db of coachs per coaches] no anexar, solo que me quedo como commit anonimo y se me agrega a cualquier rama que intento, disculpas por ese error.