### PR TITLE
ci: add autoformatter on push

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,30 @@
+name: 'Format Code'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code using Git
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Format code
+        run: pnpm run format
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[ci] format'

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "vitest",
     "test:cov": "vitest run --coverage",
     "start": "astro dev",
-		"lint": "eslint . --ext .js,.astro,.ts,.tsx",
-		"lint:fix": "eslint . --ext .js,.astro,.ts,.tsx --fix",
-		"format": "prettier --write ."
+    "lint": "eslint . --ext .js,.astro,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.astro,.ts,.tsx --fix",
+    "format": "prettier -w . --cache --plugin-search-dir=."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
**Description** 

This PR adds a format workflow that will apply prettier formatting to every push to the main branch.

This removes the need to remember to format before pushing for all contributors to make PRs cleaner. 