### PR TITLE
Add additional configuration options to .prettierrc.cjs file

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -14,5 +14,10 @@ module.exports = {
 			}
 		}
 	],
-	endOfLine: 'lf'
+	endOfLine: 'lf',
+	bracketSpacing: true,
+	quoteProps: 'as-needed',
+	arrowParens: 'always',
+	htmlWhitespaceSensitivity: 'css',
+	jsxBracketSameLine: false
 }


### PR DESCRIPTION
Hi team,

I've added several new configuration options to the .prettierrc.cjs file to give us more control over how Prettier formats our code.

- The `JsxBracketSameLine` option allows us to specify whether the closing bracket in JSX elements should be on the same line as the opening bracket or on a new line. This can help us maintain a consistent style across our codebase.

- The `htmlWhitespaceSensitivity` option lets us control how Prettier handles whitespace in HTML files. We can choose to preserve the whitespace as it appears in the source code, trim leading and trailing whitespace and collapse multiple spaces, or ignore leading and trailing whitespace and collapse multiple spaces.

- The `arrowParens` option allows us to include parentheses around the arguments of an arrow function when necessary. This can help us make our code more readable and maintain a consistent style.

- The `quoteProps` option lets us use quotes around object literal keys when necessary. This can help us avoid issues with reserved words and maintain a consistent style.

- The `bracketSpacing` option allows us to include a space between brackets in object literals. This can help us make our code more readable and maintain a consistent style.

I hope these changes will be helpful in improving the quality and readability of our code. ❤️
