### PR TITLE
fix: eslint use astro parser

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+	// ...
+	extends: ['standard', 'plugin:astro/recommended'],
+	rules: {
+		'no-tabs': 'off',
+		indent: 'off',
+		'space-before-function-paren': 'off'
+	},
+	// ...
+	overrides: [
+		{
+		files: ['*.astro'],
+		parser: 'astro-eslint-parser',
+		parserOptions: {
+			parser: '@typescript-eslint/parser',
+			extraFileExtensions: ['.astro']
+		},
+		rules: {}
+	}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "vitest",
     "test:cov": "vitest run --coverage",
     "start": "astro dev",
-		"lint": "eslint . --ext .js,.astro,.ts,.tsx",
-		"lint:fix": "eslint . --ext .js,.astro,.ts,.tsx --fix",
-		"format": "prettier --write ."
+    "lint": "eslint . --ext .js,.astro,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.astro,.ts,.tsx --fix",
+    "format": "prettier --write ."
   },
   "keywords": [],
   "author": "",
@@ -31,33 +31,14 @@
     "tailwindcss": "3.0.24"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^5.48.0",
     "@vitest/coverage-c8": "0.26.3",
+    "eslint-config-standard": "^17.0.0",
     "eslint-plugin-astro": "0.21.1",
     "prettier": "2.8.1",
     "prettier-plugin-astro": "0.7.2",
-    "standard": "17.0.0",
     "vite": "4.0.4",
     "vitest": "0.26.3",
     "wrangler": "2.6.2"
-  },
-  "eslintConfig": {
-    "extends": [
-      "standard",
-      "plugin:astro/recommended"
-    ],
-    "rules": {
-      "no-tabs": "off",
-      "indent": "off",
-      "no-unused-vars": "off",
-      "space-before-function-paren": "off"
-    },
-    "overrides": [
-      {
-        "files": [
-          "*.astro"
-        ],
-        "parser": "astro-eslint-parser"
-      }
-    ]
   }
 }


### PR DESCRIPTION
**Description**

This PR:

- installs and uses [standard eslint plugin](https://github.com/standard/eslint-config-standard)
- installs typescript parser for .astro files. (Cannot get around this because Astro uses typescript by default)
- fixes and removes unused-vars eslint rule
- move eslint config to `.eslintrc.cjs` file