### PR TITLE
fix: typeof  feat: Add more guidelines in contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,3 @@
-# To Do // To improve ?
-
-
 ## Contributing to the Kings League API 🎮
 
 **Introduction**
@@ -30,13 +27,46 @@ Before you submit a pull request, please make sure to do the following:
 
 ## Pull Request Process 🚀
 
- -  Fork the repository and create a new branch for your changes.
+ - Fork the repository and create a new branch for your changes.
  - Make the necessary changes, and commit your code with a clear commit message.
  - Push your changes to your fork.
  - Submit a pull request to the main repository.
  - The repository maintainers will review your pull request and may request changes or improvements.
  - Once the changes have been made and the pull request has been approved, it will be merged into the main branch.
 
+
+ ## Git Commit Conduct 📝
+
+  When writing commit messages, please follow these best practices:
+
+  - Use the imperative mood in your commit message. For example, "Fix bug" instead of "Fixed bug" or "Fixes bug."
+  - Avoid using exclamation points or question marks in your commit message.
+  - Keep your commit message short and concise, ideally no more than 50 characters.
+  - Use the commit message body to provide any necessary context or details about the commit.
+  - Use prefixes in your commit messages to make them more semantic.
+     Some common prefixes include:
+	     "feat" for new features,
+		 "fix" for bug fixes,
+		 "perf" for performance improvements, 
+		 "build" for changes to the build system, 
+		 "ci" for continuous integration - changes,
+		 "docs" for documentation changes, 
+		 "refactor" for refactoring changes, 
+		 "style" for formatting changes,
+		 "test" for changes to tests.
+
+  For more information about writing good commit messages, 
+  you can refer to this link: https://midu.dev/buenas-practicas-escribir-commits-git/
+
+
+## Reporting Bugs 🐛
+
+If you've found a bug in the Kings League API, we would appreciate it if you could report it to us. To report a bug, please follow these steps:
+
+1. Check the existing issues in the repository to see if the bug has already been reported. If it has, you can add your additional information to the existing issue.
+2. If the bug has not been reported, create a new issue and provide a clear and concise description of the problem.
+3. Include any relevant details, such as the version of the API you are using, the platform you are using (e.g. Windows, Mac, Linux), and the steps to reproduce the bug.
+4. If possible, include any error messages or logs that may be relevant to the problem.
 
 ## Community  🐾
 


### PR DESCRIPTION
Added the Git commit conduct guidelines to the contributing guidelines document.

Updated the Reporting Bugs section in the contributing guidelines to include information about how to properly report a bug.

Fix typeof space and "#to do" show in document user contributing 