### PR TITLE
add method for get url of each team

### DIFF
--- a/db/teams.json
+++ b/db/teams.json
@@ -3,7 +3,7 @@
     "id": "1k",
     "name": "1K FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/1k.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/1k/",
     "presidentId": "iker-casillas",
     "channel": "https://www.youtube.com/@IkerCasillas",
     "socialNetworks": [
@@ -20,7 +20,7 @@
     "id": "el-barrio",
     "name": "El Barrio",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/el-barrio.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/el-barrio/",
     "presidentId": "adri-contreras",
     "channel": "https://twitch.tv/1k",
     "socialNetworks": [
@@ -37,7 +37,7 @@
     "id": "ultimate-mostoles",
     "name": "Ultimate Móstoles",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/ultimate-mostoles.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/ultimate-mostoles/",
     "presidentId": "djmariio",
     "channel": "https://youtube.com/DjMaRiiO",
     "socialNetworks": [
@@ -51,7 +51,7 @@
     "id": "los-troncos-fc",
     "name": "Los Troncos FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/los-troncos.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/los-troncos-fc/",
     "presidentId": "perxitaa",
     "channel": "https://twitch.tv/perxitaa",
     "socialNetworks": [
@@ -68,7 +68,7 @@
     "id": "saiyans-fc",
     "name": "Saiyans FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/saiyans-fc.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/saiyans-fc/",
     "presidentId": "thegrefg",
     "channel": "https://twitch.tv/thegrefg",
     "socialNetworks": [
@@ -82,7 +82,7 @@
     "id": "kunisports",
     "name": "Kunisports",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/kunisports.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/kunisports/",
     "presidentId": "kun-aguero",
     "channel": "https://twitch.tv/slakun10",
     "socialNetworks": [
@@ -96,7 +96,7 @@
     "id": "jijantes-fc",
     "name": "Jijantes FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/jijantes.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/jijantes-fc/",
     "presidentId": "gerard-romero",
     "channel": "https://twitch.tv/gerardromero",
     "socialNetworks": [
@@ -113,7 +113,7 @@
     "id": "porcinos-fc",
     "name": "Porcinos FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/porcinos-fc.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/porcinos-fc/",
     "presidentId": "ibai-llanos",
     "channel": "https://twitch.tv/ibai",
     "socialNetworks": [
@@ -128,7 +128,7 @@
     "id": "rayo-barcelona",
     "name": "Rayo de Barcelona",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/rayo-barcelona.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/rayo-barcelona/",
     "presidentId": "spursito",
     "channel": "https://twitch.tv/spursito",
     "socialNetworks": [
@@ -145,7 +145,7 @@
     "id": "xbuyer-team",
     "name": "XBUYER TEAM",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/xbuyer.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/xbuyer-team/",
     "presidentId": "hnos-buyer",
     "channel": "https://www.youtube.com/xbuyer",
     "socialNetworks": [
@@ -159,7 +159,7 @@
     "id": "aniquiladores-fc",
     "name": "Aniquiladores FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/aniquiladores.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/aniquiladores-fc/",
     "presidentId": "juan-guarnizo",
     "channel": "https://twitch.tv/juansguarnizo",
     "socialNetworks": [
@@ -173,7 +173,7 @@
     "id": "pio-fc",
     "name": "PIO FC",
     "image": "https://kings-league-api.midudev.workers.dev/static/logos/pio.svg",
-    "url": "",
+    "url": "https://kingsleague.pro/team/pio-fc/",
     "presidentId": "rivers",
     "channel": "https://twitch.tv/rivers_gg",
     "socialNetworks": [

--- a/scraping/index.js
+++ b/scraping/index.js
@@ -1,4 +1,4 @@
-import { writeDBFile } from 'db/index.js'
+import { writeDBFile } from '../db/index.js'
 import { getURLTeams } from './url_teams.js'
 import { scrapeAndSave, SCRAPINGS } from './utils.js'
 
@@ -6,4 +6,5 @@ for (const infoToScrape of Object.keys(SCRAPINGS)) {
 	await scrapeAndSave(infoToScrape)
 }
 
-await writeDBFile('teams', getURLTeams())
+const teamsWithUrl = await getURLTeams()
+await writeDBFile('teams', teamsWithUrl)

--- a/scraping/index.js
+++ b/scraping/index.js
@@ -1,3 +1,4 @@
+import { writeDBFile } from 'db/index.js'
 import { getURLTeams } from './url_teams.js'
 import { scrapeAndSave, SCRAPINGS } from './utils.js'
 
@@ -5,4 +6,4 @@ for (const infoToScrape of Object.keys(SCRAPINGS)) {
 	await scrapeAndSave(infoToScrape)
 }
 
-getURLTeams()
+await writeDBFile('teams', getURLTeams())

--- a/scraping/index.js
+++ b/scraping/index.js
@@ -1,5 +1,8 @@
+import { getURLTeams } from './url_teams.js'
 import { scrapeAndSave, SCRAPINGS } from './utils.js'
 
 for (const infoToScrape of Object.keys(SCRAPINGS)) {
 	await scrapeAndSave(infoToScrape)
 }
+
+getURLTeams()

--- a/scraping/url_teams.js
+++ b/scraping/url_teams.js
@@ -1,0 +1,18 @@
+import { TEAMS } from '../db/index.js'
+
+export async function getURLTeams($) {
+	/*
+		Las url de la informacion de cada equipo tiene siempre
+		el patron de la url base 'https://kingsleague.pro/team/'
+		añadiendole el id del equipo.
+
+		Se generan siguiendo este patron de las url de la pagina
+		oficial.
+	*/
+	return TEAMS.map((team) => {
+		return {
+			...team,
+			url: `https://kingsleague.pro/team/${team.id}/`
+		}
+	})
+}


### PR DESCRIPTION
Es un método que utiliza un patrón de la url de la información de cada equipo de la pagina oficial.

Explicacion de patron de la url:
      Las url de la información de cada equipo tiene siempre el patrón de la url base 'https://kingsleague.pro/team/'
      añadiéndole el id del equipo.

Ahí lo añado a que se ejecute luego de que haga el scraping de las paginas ya que este como tal no scrapea sino que lo genera automáticamente en local.