### PR TITLE
fix: delete rank key on top_scorer scrapper

### DIFF
--- a/scraping/top_scorer.js
+++ b/scraping/top_scorer.js
@@ -2,7 +2,6 @@ import { TEAMS } from '../db/index.js'
 import { cleanText } from './utils.js'
 
 const SCORES_SELECTORS = {
-	ranking: { selector: '.fs-table-text_1', typeOf: 'string' },
 	team: { selector: '.fs-table-text_3', typeOf: 'string' },
 	playerName: { selector: '.fs-table-text_4', typeOf: 'string' },
 	gamesPlayed: { selector: '.fs-table-text_5', typeOf: 'number' },
@@ -34,8 +33,8 @@ export async function getTopScoresList($) {
 		const image = getImageFromTeam({ name: teamName })
 
 		topScorerList.push({
+			ranking: index + 1,
 			...scorerData,
-			rank: index + 1,
 			team: teamName,
 			image
 		})


### PR DESCRIPTION
Delete the `rank` key to keep only `ranking` on top_scorer scrapper, fixing the issues https://github.com/midudev/kings-league-project/issues/61