### PR TITLE
add .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+


### PR DESCRIPTION
Added the `.npmrc` file with the `save-exact=true` option, to force the installation of the exact version of each new package that is installed, without the `-E` flag of PNPM