### PR TITLE
fix: mvp endpoint description

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -38,7 +38,7 @@ app.get('/', (ctx) =>
 		},
 		{
 			endpoint: '/mvp',
-			description: 'Returns Kings League Top Scorers'
+			description: 'Returns Kings League Most Valuable Players'
 		}
 	])
 )


### PR DESCRIPTION
It seems that the description was copypasted from the top-scorers endpoint.