### PR TITLE
add info of parameters in routes that use this

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -18,11 +18,23 @@ app.get('/', (ctx) =>
 		},
 		{
 			endpoint: '/teams',
-			description: 'Returns Kings League teams'
+			description: 'Returns Kings League teams',
+			parameters: [
+				{
+					name: 'id',
+					endpoint: '/teams/:id'
+				}
+			]
 		},
 		{
 			endpoint: '/presidents',
-			description: 'Returns Kings League presidents'
+			description: 'Returns Kings League presidents',
+			parameters: [
+				{
+					name: 'id',
+					endpoint: '/presidents/:id'
+				}
+			]
 		},
 		{
 			endpoint: '/coaches',


### PR DESCRIPTION
Añade la información de las posibles rutas con parámetros como `/teams` y `/presidents` con el parámetro `:id`