### PR TITLE
fix: add info at new routes and description at all routes with params 

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -22,7 +22,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'id',
-					endpoint: '/teams/:id'
+					endpoint: '/teams/:id',
+					description: 'Return Kings League team by id'
 				}
 			]
 		},
@@ -32,7 +33,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'id',
-					endpoint: '/presidents/:id'
+					endpoint: '/presidents/:id',
+					description: 'Return Kings League president by id'
 				}
 			]
 		},
@@ -46,7 +48,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'rank',
-					endpoint: '/top-assists/:rank'
+					endpoint: '/top-assists/:rank',
+					description: 'Return Kings League top assister by rank'
 				}
 			]
 		},
@@ -56,7 +59,8 @@ app.get('/', (ctx) =>
 			parameters: [
 				{
 					name: 'rank',
-					endpoint: '/top-scorers/:rank'
+					endpoint: '/top-scorers/:rank',
+					description: 'Return Kings League top scorer by rank'
 				}
 			]
 		},

--- a/api/index.js
+++ b/api/index.js
@@ -42,11 +42,23 @@ app.get('/', (ctx) =>
 		},
 		{
 			endpoint: '/top-assists',
-			description: 'Returns Kings League Top Assists'
+			description: 'Returns Kings League Top Assists',
+			parameters: [
+				{
+					name: 'rank',
+					endpoint: '/top-assists/:rank'
+				}
+			]
 		},
 		{
 			endpoint: '/top-scorers',
-			description: 'Returns Kings League Top Scorers'
+			description: 'Returns Kings League Top Scorers',
+			parameters: [
+				{
+					name: 'rank',
+					endpoint: '/top-scorers/:rank'
+				}
+			]
 		},
 		{
 			endpoint: '/mvp',


### PR DESCRIPTION
Añado la información de las nuevas rutas añadidas y una descripción a cada ruta que tenga algún parámetro.

`New routes:`
GET `top-scorers/:rank` 
GET `top-assists/:rank` 

Estas y el resto de rutas con parámetros se les añadió una pequeña descripción.
