### PR TITLE
Prevent images to stretch

### DIFF
--- a/src/components/TeamsSelectorCards.astro
+++ b/src/components/TeamsSelectorCards.astro
@@ -20,7 +20,7 @@ const teams = await getAllTeams()
 					>
 						<img
 							alt={`Logo del equipo ${name}`}
-							class='brightness-[100] transition-all group-hover:scale-110 group-hover:brightness-200 z-10 w-28 h-28 [backface-visibility:hidden]'
+							class='brightness-[100] object-contain transition-all group-hover:scale-110 group-hover:brightness-200 z-10 w-28 h-28 [backface-visibility:hidden]'
 							src={imageWhite}
 						/>
 						<h3 class='z-10 font-title text-white text-xl xl:text-2xl'>{name}</h3>

--- a/src/pages/team/[teamId].astro
+++ b/src/pages/team/[teamId].astro
@@ -36,8 +36,12 @@ const president = await findPresidentBy({ id: presidentId })
 			>
 				<section class='flex items-center justify-between pb-60'>
 					<div class='flex flex-col items-center'>
-						<div class="flex items-center gap-x-6">
-							<img class='w-48 h-48' src={imageWhite} alt={`Escudo del equipo ${name}`} />
+						<div class='flex items-center gap-x-6'>
+							<img
+								class='w-48 h-48 object-contain'
+								src={imageWhite}
+								alt={`Escudo del equipo ${name}`}
+							/>
 							<div class='flex flex-col gap-y-4'>
 								<h1 class='font-title font-bold text-6xl text-white'>{name}</h1>
 								<ul class='flex flex-row gap-x-4'>


### PR DESCRIPTION
Add `object-contain` class to avoid stretching images on `TeamsSelectorCards` component.

Before:

![image](https://user-images.githubusercontent.com/94259578/211108295-9700cc53-2a60-4acb-8036-d01ad4c7379e.png)


After: 

![image](https://user-images.githubusercontent.com/94259578/211108254-8cf37dd7-d85b-4e95-94ca-09b7901067df.png)

Add `object-contain` class to avoid stretching images on `team/[teamId]` page.

Before: 

![image](https://user-images.githubusercontent.com/94259578/211128708-d34f56f3-924b-4754-8263-5cb07e3deb78.png)

After:

![image](https://user-images.githubusercontent.com/94259578/211128718-d4ce389d-6fc7-4675-8d3c-93cc8059f9e3.png)
