### PR TITLE
fix: warning -  'channel' is assigned a value but never used

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,6 @@
 ---
-import Header from '@components/Header.astro';
-import Footer from '@components/Footer.astro';
+import Header from '@components/Header.astro'
+import Footer from '@components/Footer.astro'
 
 const {
 	title,

--- a/src/pages/team/[teamId].astro
+++ b/src/pages/team/[teamId].astro
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
 	}))
 }
 
-const { id, name, imageWhite, presidentId, socialNetworks, channel, players, color } = Astro.props
+const { id, name, imageWhite, presidentId, socialNetworks, players, color } = Astro.props
 
 const socialNetworksWithIcon = socialNetworks.map((href) => ({
 	href,
@@ -93,7 +93,7 @@ const president = await findPresidentBy({ id: presidentId })
 				</section>
 
 				<div
-					class={`-z-10 absolute inset-0 opacity-5 bg-center bg-[size:80%] transition bg-no-repeat`}
+					class={'-z-10 absolute inset-0 opacity-5 bg-center bg-[size:80%] transition bg-no-repeat'}
 					style={`background-image:url('${imageWhite}')`}
 				>
 				</div>


### PR DESCRIPTION
Uh oh, looks like we've got a little rebel on our hands! 'channel' here decided to go rogue and cause some trouble, but we were able to tame it and put it back in its place. All's well that ends well, right?
🍻
