### PR TITLE
coverage report and new tests

### DIFF
--- a/db/index.test.js
+++ b/db/index.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { writeDBFile, TEAMS, PRESIDENTS, getImageFromTeam } from './index'
+
+describe('testing db functionality', () => {
+	it('saves data to JSON file', () => {
+		writeDBFile('dummy', { data: 'dummy' })
+	})
+	it('teams  and presidents haves values', () => {
+		expect(TEAMS).toBeDefined()
+		expect(PRESIDENTS).toBeDefined()
+	})
+	it('returns team image', () => {
+		const image = getImageFromTeam({ name: '1K FC' })
+		expect(image).toBe('https://api.kingsleague.dev/static/logos/1k.svg')
+	})
+})

--- a/global-setup/shared-mocks.js
+++ b/global-setup/shared-mocks.js
@@ -1,0 +1,19 @@
+import { vi } from 'vitest'
+import { writeDBFile } from '../db/index'
+
+/**
+ * the mock for writeDBFile will prevent accidental
+ * writes on db files while testing
+ */
+export default async function () {
+	vi.mock('../db/index.js', async (importActual) => {
+		const actual = await vi.importActual('../db/index.js')
+		return {
+			...actual,
+			writeDBFile: (file, data) => {
+				console.log(`saving...`)
+			}
+		}
+	})
+	await sleep(25)
+}

--- a/scraping/utils.test.js
+++ b/scraping/utils.test.js
@@ -1,0 +1,16 @@
+import { cleanText } from './utils'
+import { describe, expect, it } from 'vitest'
+
+describe('test utils functions', () => {
+	it('removes extra spaces, or breaklines from strings', () => {
+		const text = 'this is \nan \texample'
+		const cleanedText = cleanText(text)
+		expect(cleanedText).toBe('this is an example')
+	})
+
+	it('removes everything behind Colon mark :', () => {
+		const text = 'name: jhon doe'
+		const cleanedText = cleanText(text)
+		expect(cleanedText).toBe('jhon doe')
+	})
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  test: {},
+	test: {
+		setupFiles: ['./global-setup/shared-mocks.js'],
+		coverage: {
+			all: true
+		}
+	}
 })


### PR DESCRIPTION
this PR configures coverage report, mocks `writeDBFile` to avoid accidentals re-writtes on db files while testing and also includes some unit testing

Current code Coverage

![image](https://user-images.githubusercontent.com/22009810/211129833-c7f4ce3e-66b1-4328-b6ff-83ba82295109.png)
