### PR TITLE
fix recommandable to recommended on CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Before you submit a pull request, please make sure to do the following:
 - Ensure that your code follows the style guide for the project.
 - Write tests for any new code you have added.
 - Make sure that all tests pass.
-- Update the documentation to reflect any changes. (recommendable)
+- Update the documentation to reflect any changes. (recommended)
 
 ## Pull Request Process 🚀
 


### PR DESCRIPTION
"Recommended" can be an adjective, and you should normally use it instead of "recommendable".

"Recommendable" means that something CAN be recommended, but does not say that it HAS been.

You mostly see "recommendable" on negative statements ("that is not recommendable").