### PR TITLE
feat: home page responsive

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,10 +12,10 @@ import UneteButton from '@components/Unete.astro'
 		<section class='bg-[#cd5500] py-20'>
 			<Container>
 				<div class='grid grid-cols-8 gap-10 w-full px-10'>
-					<div class="col-span-3">
+					<div class='col-span-12 lg:col-span-4 xl:col-span-3'>
 						<Table />
 					</div>
-					<div class='col-span-5'>
+					<div class='col-span-12 lg:col-span-4 xl:col-span-5'>
 						<div class='grid grid-cols-6 gap-y-10 gap-x-5 w-full'>
 							<!-- MVP -->
 
@@ -34,9 +34,8 @@ import UneteButton from '@components/Unete.astro'
 							<div class='col-span-3 bg-white 500 h-80 rounded-'>
 								<!-- Card component here -->
 							</div>
-
 						</div>
-						<div class="my-5">
+						<div class='my-5'>
 							<TeamsSelectorCards small />
 						</div>
 					</div>


### PR DESCRIPTION
Make home page responsive.

Some after/before screenshots below:

Before in 920px:

![old-920px](https://user-images.githubusercontent.com/98661193/211157477-d8f4ef47-2b2d-4659-87fe-e356af5dd0bd.png)

After in 920px:

![new-920px](https://user-images.githubusercontent.com/98661193/211157491-618f8405-68d2-4477-9de5-b91bc55e59fd.png)

Before in 1200px:

![old-1200px](https://user-images.githubusercontent.com/98661193/211157563-618297dc-45bc-4692-91cc-f8571d90a1dc.png)

After in 1200px:

![new-1200px](https://user-images.githubusercontent.com/98661193/211157571-7419e403-506d-4713-b448-6174bd9e56ba.png)


In full screen (1920x1080) it remains the same:
Before in full screen:

![old-full-screen](https://user-images.githubusercontent.com/98661193/211157656-66a29de5-fd98-48a1-9a1e-a650237ccb52.png)

After in full screen:

![new-full-screen](https://user-images.githubusercontent.com/98661193/211157682-83484d3d-99db-4fff-90e9-226e7d42bc91.png)

