### PR TITLE
Fix scrape parameter

### DIFF
--- a/scraping/index.js
+++ b/scraping/index.js
@@ -7,7 +7,7 @@ import { scrapeAndSave, SCRAPINGS } from './utils.js'
 // get first parameter from command line
 const scrapeParameter = process.argv.at(-1)
 
-if (scrapeParameter) {
+if (SCRAPINGS[scrapeParameter]) {
 	await scrapeAndSave(scrapeParameter)
 } else {
 	logInfo('Scraping all data...')


### PR DESCRIPTION
Al momento de utilizar el scrape, si no se le envia un parametro, da un error, ya que tomaba la ruta como parametro (scraping/index.js). Para resolverlo, el parametro que se envia debe existir en las key de SCRAPINGS para poder ser scrapeado, si no existe o no se envia el parametro, se hace el scrape completo.