### PR TITLE
add basic SEO optimizations

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 
 import tailwind from "@astrojs/tailwind";
 import prefetch from "@astrojs/prefetch";
+import sitemap from "@astrojs/sitemap";
 
 const website = "https://kingsleague.dev/";
 
@@ -11,5 +12,11 @@ export default defineConfig({
   server: {
     host: true,
   },
-  integrations: [tailwind(), prefetch()],
+  integrations: [
+    tailwind(),
+    prefetch(),
+    sitemap({
+      lastmod: new Date(),
+    }),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tailwindcss": "3.2.4"
   },
   "devDependencies": {
+    "@astrojs/sitemap": "1.0.0",
     "@typescript-eslint/parser": "5.48.0",
     "@vitest/coverage-c8": "0.26.3",
     "@vitest/ui": "0.26.3",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: https://kingsleague.dev/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,9 +18,10 @@ const seoTitle = title
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
 		<title>{seoTitle}</title>
 		<meta name="description" content={description} />
+		<link href={Astro.url.href} rel="canonical" />
+		<meta name="generator" content={Astro.generator} />
 		<link href="/fonts/archivo.woff2" rel="preload" type="font/woff2" as="font" fetchpriority="high" crossorigin />
 		<link href="/fonts/archivo-semibold.woff2" rel="preload" type="font/woff2" as="font" fetchpriority="high" crossorigin />
 		<link href="/fonts/archivo-black.woff2" rel="preload" type="font/woff2" as="font" fetchpriority="high" crossorigin />


### PR DESCRIPTION
- Created `robots.txt` file. The option `Sitemap` include the name generated by the [@astrojs/sitemap](https://docs.astro.build/es/guides/integrations-guide/sitemap/) integration (See: [https://docs.astro.build/es/guides/integrations-guide/sitemap/#example-of-generated-files-for-a-two-page-website](https://docs.astro.build/es/guides/integrations-guide/sitemap/#example-of-generated-files-for-a-two-page-website))
- Add  [@astrojs/sitemap](https://docs.astro.build/es/guides/integrations-guide/sitemap/) to generate a `sitemap-index.xml` on every build.
- Added a canonical url generation for every path on src/layouts/Layout.astro.