### PR TITLE
extract critical css

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 
 import tailwind from "@astrojs/tailwind";
+import critters from "astro-critters";
 import prefetch from "@astrojs/prefetch";
 import sitemap from "@astrojs/sitemap";
 
@@ -14,6 +15,7 @@ export default defineConfig({
   },
   integrations: [
     tailwind(),
+    critters(),
     prefetch(),
     sitemap({
       lastmod: new Date(),

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/parser": "5.48.0",
     "@vitest/coverage-c8": "0.26.3",
     "@vitest/ui": "0.26.3",
+    "astro-critters": "1.1.25",
     "eslint": "8.31.0",
     "eslint-config-standard": "17.0.0",
     "eslint-plugin-astro": "0.21.1",


### PR DESCRIPTION
I have installed the [astro-critters](https://github.com/astro-community/astro-critters) integration, which use [Critters](https://github.com/GoogleChromeLabs/critters) under the hood to extract the Critical CSS and lazy load the rest on every path of the project. This improve the First Contentful Paint metric.