### PR TITLE
chore: modify player name and position

### DIFF
--- a/src/components/TeamPagePlayers.astro
+++ b/src/components/TeamPagePlayers.astro
@@ -4,7 +4,7 @@ const { players, title } = Astro.props
 
 <section>
 	<h2 class='font-title text-5xl text-white text-center py-10'>{title}</h2>
-	<div class='grid md:grid-cols-3 xl:grid-cols-4 gap-2'>
+	<div class='grid grid-cols-4 gap-2'>
 		{
 			players.map((player) => (
 				<article class='text-center relative font-title text-slate-900 rounded-sm p-5 m-auto'>
@@ -15,10 +15,12 @@ const { players, title } = Astro.props
 						decoding='async'
 						fetchpriority='high'
 					/>
-					<h3 class='text-white font-title text-3xl pt-2'>{player.name}</h3>
-					<h4 class='font-body uppercase rounded-full text-orange-500 bg-black/70 py-1 font-semibold'>
-						{player.role}
-					</h4>
+					<div class="bg-black/70 rounded-xl">
+						<h3 class='text-white font-title text-3xl pt-2'>{player.name}</h3>
+						<h4 class='font-body uppercase  text-orange-500  py-1 font-semibold'>
+							{player.role}
+						</h4>
+					</div>
 				</article>
 			))
 		}


### PR DESCRIPTION
Las fotos de los jugadores se cortan en el vacio y me parece mejor cortarla visualmente con algo.

![image](https://user-images.githubusercontent.com/2835435/211167052-9e83f320-2047-4869-9c46-bfbf9ab8602d.png)

![image](https://user-images.githubusercontent.com/2835435/211167031-e00e5e87-8930-4064-be05-291f99931b15.png)
