### PR TITLE
Fix expected url in db/index.test.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ package-lock.json
 /coverage
 # Ignore build folder of Astro
 /dist
+
+# Webstorm folder
+/.idea

--- a/db/index.test.js
+++ b/db/index.test.js
@@ -11,6 +11,6 @@ describe('testing db functionality', () => {
 	})
 	it('returns team image', () => {
 		const image = getImageFromTeam({ name: '1K FC' })
-		expect(image).toBe('https://api.kingsleague.dev/static/logos/1k.svg')
+		expect(image).toBe('https://kingsleague.dev/teams/logos/1k.svg')
 	})
 })


### PR DESCRIPTION
This test isn't passed because of an error in the expected URL

![Screenshot from 2023-01-07 18-51-32](https://user-images.githubusercontent.com/30879476/211174501-d23d978c-41e4-400c-bdc9-2eeb8d81ff26.png)

In this PR the URL is corrected and the folder of webstorm configuration is ignored 