### PR TITLE
🧪 Add: new test for president route

### DIFF
--- a/api/index.test.js
+++ b/api/index.test.js
@@ -162,6 +162,20 @@ describe('Testing /presidents route', () => {
 			message: 'President not found'
 		})
 	})
+
+	it('should filter presidents by team using the "team" parameter', async () => {
+		const resp = await worker.fetch('/presidents?team=1k')
+		expect(resp).toBeDefined()
+
+		const presidents = await resp.json()
+		expect(presidents).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					teamId: '1k'
+				})
+			])
+		)
+	})
 })
 
 describe('Test /schedule route', () => {

--- a/db/index.test.js
+++ b/db/index.test.js
@@ -11,6 +11,6 @@ describe('testing db functionality', () => {
 	})
 	it('returns team image', () => {
 		const image = getImageFromTeam({ name: '1K FC' })
-		expect(image).toBe('https://api.kingsleague.dev/static/logos/1k.svg')
+		expect(image).toBe('https://kingsleague.dev/teams/logos/1k.svg')
 	})
 })


### PR DESCRIPTION
I add 1 new test for president  route 🧪

- This test sends a request to the /presidents route with the query parameter "team" set to "1k". It then expects the response to be defined and for the returned JSON to contain an array of presidents. It further expects that array to contain at least one president object that has a "teamId" property with a value of "1k". This test is likely checking that the /presidents route is able to filter the returned presidents by team using the "team" query parameter.

Cheers 🍻