### PR TITLE
send the information of routes at new file and use in the root route 

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -10,90 +10,12 @@ import topAssists from '../db/top_assists.json'
 import schedule from '../db/schedule.json'
 import playersTwelve from '../db/players_twelve.json'
 import topStatistics from '../db/top_statistics.json'
+import infoRoutes from '../db/info_routes.json'
 
 const app = new Hono()
 
 app.get('/', (ctx) =>
-	ctx.json([
-		{
-			endpoint: '/leaderboard',
-			description: 'Returns Kings League leaderboard',
-			parameters: [
-				{
-					name: 'team',
-					endpoint: '/leaderboard/:teamId',
-					description: 'Return Kings League leaderboard info from Team Id'
-				}
-			]
-		},
-		{
-			endpoint: '/teams',
-			description: 'Returns Kings League teams',
-			parameters: [
-				{
-					name: 'id',
-					endpoint: '/teams/:id',
-					description: 'Return Kings League team by id'
-				}
-			]
-		},
-		{
-			endpoint: '/presidents',
-			description: 'Returns Kings League presidents',
-			parameters: [
-				{
-					name: 'id',
-					endpoint: '/presidents/:id',
-					description: 'Return Kings League president by id'
-				}
-			]
-		},
-		{
-			endpoint: '/coaches',
-			description: 'Returns Kings League coaches',
-			parameters: [
-				{
-					name: 'teamId',
-					endpoint: '/top-assists/:teamId',
-					description: 'Return Kings League coach of team by id of some'
-				}
-			]
-		},
-		{
-			endpoint: '/top-assists',
-			description: 'Returns Kings League Top Assists',
-			parameters: [
-				{
-					name: 'rank',
-					endpoint: '/top-assists/:rank',
-					description: 'Return Kings League top assister by rank'
-				}
-			]
-		},
-		{
-			endpoint: '/top-scorers',
-			description: 'Returns Kings League Top Scorers',
-			parameters: [
-				{
-					name: 'rank',
-					endpoint: '/top-scorers/:rank',
-					description: 'Return Kings League top scorer by rank'
-				}
-			]
-		},
-		{
-			endpoint: '/mvp',
-			description: 'Returns Kings League Most Valuable Players'
-		},
-		{
-			endpoint: '/schedule',
-			description: 'Returns Kings League match schedule and the final score of played games.'
-		},
-		{
-			endpoint: '/players-12',
-			description: 'Returns Kings League Players Twelve'
-		}
-	])
+	ctx.json(infoRoutes)
 )
 
 app.get('/leaderboard', (ctx) => {

--- a/db/info_routes.json
+++ b/db/info_routes.json
@@ -1,0 +1,80 @@
+[
+  {
+    "endpoint": "/leaderboard",
+    "description": "Returns Kings League leaderboard",
+    "parameters": [
+      {
+        "name": "team",
+        "endpoint": "/leaderboard/:teamId",
+        "description": "Return Kings League leaderboard info from Team Id"
+      }
+    ]
+  },
+  {
+    "endpoint": "/teams",
+    "description": "Returns Kings League teams",
+    "parameters": [
+      {
+        "name": "id",
+        "endpoint": "/teams/:id",
+        "description": "Return Kings League team by id"
+      }
+    ]
+  },
+  {
+    "endpoint": "/presidents",
+    "description": "Returns Kings League presidents",
+    "parameters": [
+      {
+        "name": "id",
+        "endpoint": "/presidents/:id",
+        "description": "Return Kings League president by id"
+      }
+    ]
+  },
+  {
+    "endpoint": "/coaches",
+    "description": "Returns Kings League coaches",
+    "parameters": [
+      {
+        "name": "teamId",
+        "endpoint": "/top-assists/:teamId",
+        "description": "Return Kings League coach of team by id of some"
+      }
+    ]
+  },
+  {
+    "endpoint": "/top-assists",
+    "description": "Returns Kings League Top Assists",
+    "parameters": [
+      {
+        "name": "rank",
+        "endpoint": "/top-assists/:rank",
+        "description": "Return Kings League top assister by rank"
+      }
+    ]
+  },
+  {
+    "endpoint": "/top-scorers",
+    "description": "Returns Kings League Top Scorers",
+    "parameters": [
+      {
+        "name": "rank",
+        "endpoint": "/top-scorers/:rank",
+        "description": "Return Kings League top scorer by rank"
+      }
+    ]
+  },
+  {
+    "endpoint": "/mvp",
+    "description": "Returns Kings League Most Valuable Players"
+  },
+  {
+    "endpoint": "/schedule",
+    "description": "Returns Kings League match schedule and the final score of played games."
+  },
+  {
+    "endpoint": "/players-12",
+    "description": "Returns Kings League Players Twelve"
+  }
+]


### PR DESCRIPTION
Envió la información de las rutas que muestra la ruta inicial (`/`) a un nuevo archivo (`info_routes.json`) en la carpeta `db` y luego se importa y se utiliza en la misma ruta inicial.