### PR TITLE
fix: team styling

### DIFF
--- a/src/components/TeamPagePlayers.astro
+++ b/src/components/TeamPagePlayers.astro
@@ -7,7 +7,7 @@ const { players, title } = Astro.props
 	<div class='grid grid-cols-2 md:grid-cols-4 gap-2'>
 		{
 			players.map((player) => (
-				<article class='text-center relative font-title text-slate-900 rounded-sm p-5 m-auto'>
+				<article class='text-center relative font-title text-slate-900 rounded-sm p-1 md:p-5 m-auto'>
 					<img
 						class='w-56 h-auto m-auto aspect-[170/239]'
 						src={`/teams/players/${player.image}`}

--- a/src/components/TeamStats.astro
+++ b/src/components/TeamStats.astro
@@ -40,7 +40,7 @@ const stats = [
 
 <div class='flex'>
 	<section
-		class='p-8 rounded-lg mt-5 grid grid-cols-3 gap-y-2 gap-x-12 bg-gradient-to-tr from-[#202020c9] via-[#36363685] to-[#cd55002a] shadow-xl'
+		class='p-10 md:p-8 rounded-lg mt-5 grid grid-cols-3 gap-y-2 gap-x-12 bg-gradient-to-tr from-[#202020c9] via-[#36363685] to-[#cd55002a] shadow-xl'
 	>
 		{
 			stats.map((stat) => (
@@ -52,7 +52,7 @@ const stats = [
 					first:row-start-1
 					first:row-end-4
 					[&>strong]:first:text-[9em] [&>strong]:first:leading-[1em]
-					[&>h4]:first:text-[1.6em]
+					[&>h4]:first:text-[1.5em]
 					first:justify-center
 					first:items-center'
 				>

--- a/src/pages/team/[teamId].astro
+++ b/src/pages/team/[teamId].astro
@@ -33,7 +33,9 @@ export async function getStaticPaths() {
 <Layout title={name}>
 	<section class='bg-principal py-20'>
 		<Container>
-			<div class={`relative p-0 md:px-20 md:py-10 shadow-xl rounded -mt-10 z-10 mb-40 ${gradient}`}>
+			<div
+				class={`relative py-10 px-2 md:px-20 md:py-10 shadow-xl rounded -mt-10 z-10 mb-40 ${gradient}`}
+			>
 				<section class='flex flex-col xl:flex-row items-center justify-between pb-10'>
 					<div class='flex flex-col'>
 						<div class='flex flex-col xl:flex-row items-center gap-x-6 mb-2'>


### PR DESCRIPTION
# What was done 👀

In this pull request I am aiming to fix some styling issues related with how the team interface looks on mobile, I changed the "posición" title to 1.5 because before this the content was overflowing.

Note that the player grid was also modified so the player grid fits on the screen.

# Screenshots
<img width="300px" src="https://user-images.githubusercontent.com/30534965/211178817-5ecc0cb8-6aa8-451e-a9ed-be40eda773f7.png"/>
<img width="300px" src="https://user-images.githubusercontent.com/30534965/211178822-8b9e4e8a-caa2-4972-a563-d23900fcde25.png"/>
<img width="300px" src="https://user-images.githubusercontent.com/30534965/211178825-d2e3918d-1914-4757-96c0-d882b4bd0bcb.png"/>
