### PR TITLE
fix: scrapper action when don't have db changes

### DIFF
--- a/.github/workflows/scrape-kings-league-web.yml
+++ b/.github/workflows/scrape-kings-league-web.yml
@@ -8,7 +8,7 @@ on:
       - webhook
 
   schedule:
-    - cron: "0 */1 * * 0"
+    - cron: '0 */1 * * 0'
 
 jobs:
   build:
@@ -25,16 +25,5 @@ jobs:
       - run: |
           npm run scrape
           git config user.name kings-league-bot
-          git add -A
-          git commit -m "[bot] Update Kings League Database"
+          git diff --quiet && git diff --staged --quiet || git commit -am "[bot] update Kings League database"
           git push origin main
-          
-          
-          
-          
-          
-          
-          
-          
-          
-          


### PR DESCRIPTION
When scraped and we don't have a change, we get an error from GIT when we try to commit. Now we don't have any errors when trying to commit. We check first if we have any changes, and after we add and commit. 

Before (without changes in db): 
![Screenshot from 2023-01-08 11-37-48](https://user-images.githubusercontent.com/41394649/211185739-6e0c1f2e-a614-49b6-8323-dbd719fd83f4.png)

After(without changes in db): 
![Screenshot from 2023-01-08 11-38-04](https://user-images.githubusercontent.com/41394649/211185737-3680a5b1-c0dd-4471-b473-222b68081220.png)


