### PR TITLE
Fix menu reponsive on teams page

### DIFF
--- a/src/components/TeamsSelectorCards.astro
+++ b/src/components/TeamsSelectorCards.astro
@@ -15,7 +15,7 @@ const { small } = Astro.props
 			return (
 				<article class={`overflow-hidden col-span-1 rounded aspect-video ${gradient}`}>
 					<a
-						class='group transition-all hover:scale-110 flex gap-x-4 p-4 h-full items-center justify-center relative'
+						class='group transition-all hover:scale-110 flex gap-x-4 p-4 h-full items-center justify-center relative z-0'
 						href={`/team/${id}`}
 						title={`Ver equipo ${name}`}
 						rel={Astro.url.pathname !== `/team/${id}` && 'preload'}


### PR DESCRIPTION
Before:
![Screenshot_2023-01-08-12-47-24-35_40deb401b9ffe8e1df2f1cc5ba480b12](https://user-images.githubusercontent.com/15101708/211194721-1807f54b-b7e5-4de6-add2-41cd21532358.jpg)

Now:
![descarga (5)](https://user-images.githubusercontent.com/15101708/211194731-4b9cfd7d-30f3-445f-9492-c8a612e860e9.png)
