### PR TITLE
Fix: Schedule row / responsive.

### DIFF
--- a/src/components/ScheduleRow.astro
+++ b/src/components/ScheduleRow.astro
@@ -2,7 +2,8 @@
 const { local, score, visitant, useSmallNames, hour, timestamp } = Astro.props
 
 const scoreStyles = {
-	shared: 'text-center font-title rounded-md p-2 px-10 md:px-20 text-sm lg:text-xl leading-none',
+	shared:
+		'text-center whitespace-nowrap font-title rounded-md p-2 px-10 md:px-20 text-sm lg:text-xl leading-none',
 	played: 'text-white bg-gray-700',
 	pending: 'bg-gray-200 transition group-hover:bg-gray-200'
 }
@@ -16,31 +17,30 @@ if (timestamp && timestamp <= Date.now()) {
 } else if (hour) {
 	text = `${hour}h`
 }
-
 ---
 
 <tr
 	class='odd:bg-white even:bg-slate-100 flex justify-between group border-y [&>td]:py-2 transition hover:bg-gray-100'
 >
-	<td class='lg:px-2 py-4 border-b-1 flex flex-col 2xl:flex-row justify-start items-center w-full'>
+	<td class='lg:px-2 py-4 border-b-1 flex flex-col md:flex-row justify-start items-center w-full'>
 		<img
-			class='w-6 lg:w-12 h-6 lg:h-12 mx-2'
+			class='w-6 h-6 lg:w-12 lg:h-12 mx-2'
 			src={`https://kingsleague.dev/teams/logos/${local.id}.svg`}
 			alt={`Escudo del equipo ${local.name}`}
 		/>
 		<a title={local.name} href={`/team/${local.id}`}>
-		{
-			useSmallNames
-? (
-				<span class='font-bold font-title' title={local.name}>{local.shortName}</span>
-			)
-: (
-				<>
-					<span class='md:hidden'>{local.shortName}</span>
-					<span class='hidden md:block'>{local.name}</span>
-				</>
-			)
-		}
+			{
+				useSmallNames ? (
+					<span class='font-bold font-title' title={local.name}>
+						{local.shortName}
+					</span>
+				) : (
+					<>
+						<span class='md:hidden'>{local.shortName}</span>
+						<span class='hidden md:block'>{local.name}</span>
+					</>
+				)
+			}
 		</a>
 	</td>
 
@@ -48,24 +48,24 @@ if (timestamp && timestamp <= Date.now()) {
 		<span class={`${scoreStyles.shared} ${scoreStyles[state]}`}>{text}</span>
 	</td>
 
-	<td class='lg:px-2 py-4 border-b-1 flex flex-col 2xl:flex-row justify-end items-center w-full'>
-		<a title={visitant.name} href={`/team/${visitant.id}`} class="order-2 2xl:order-1">
-		{
-			useSmallNames
-? (
-				<span class='font-bold font-title' title={visitant.name}>{visitant.shortName}</span>
-			)
-: (
-				<>
-					<span class='md:hidden'>{visitant.shortName}</span>
-					<span class='hidden md:block'>{visitant.name}</span>
-				</>
-			)
-		}
+	<td class='lg:px-2 py-4 border-b-1 flex flex-col md:flex-row justify-end items-center w-full'>
+		<a title={visitant.name} href={`/team/${visitant.id}`} class='order-2 2xl:order-1'>
+			{
+				useSmallNames ? (
+					<span class='font-bold font-title' title={visitant.name}>
+						{visitant.shortName}
+					</span>
+				) : (
+					<>
+						<span class='md:hidden'>{visitant.shortName}</span>
+						<span class='hidden md:block'>{visitant.name}</span>
+					</>
+				)
+			}
 		</a>
 
 		<img
-			class='w-12 h-12 mx-2 order-1 2xl:order-2'
+			class='w-6 h-6 lg:w-12 lg:h-12 mx-2 order-1 2xl:order-2'
 			src={`https://kingsleague.dev/teams/logos/${visitant.id}.svg`}
 			alt={`Escudo del equipo ${visitant.name}`}
 		/>

--- a/src/pages/calendario/index.astro
+++ b/src/pages/calendario/index.astro
@@ -12,8 +12,10 @@ const schedule = await getSchedule()
 <Layout title='Calendario'>
 	<SectionTitle title='Calendario' />
 	<Container>
-		<main class='bg-white p-20 shadow-xl rounded -mt-10 z-10 mb-40 flex justify-center flex-col'>
-			<div class='max-w-5xl mx-auto my-4 px-10'>
+		<main
+			class='bg-white p-8 sm:p-20 shadow-xl rounded -mt-10 z-10 mb-40 flex justify-center flex-col'
+		>
+			<div class='max-w-5xl mx-auto my-4'>
 				{
 					schedule.map((day) => {
 						return (


### PR DESCRIPTION
Fix #188. 

Chances on `/calendario` page (Device: iPhone 12/13 mini):

<table><tr><td>
    <p>Before:</p>
    <img src="https://user-images.githubusercontent.com/94259578/211196863-1f7e4eb2-f3a2-4eb7-ae2b-d790bb75c317.png" height="440px"/>
</td><td>
    <p>After:</p>
    <img src="https://user-images.githubusercontent.com/94259578/211196895-dc507d26-fa0c-4a02-a761-4f83b67d798e.png" height="440px"/>
</td></tr></table>

Chances on `/` page (Device: iPhone 12/13 mini):

<table><tr><td>
    <p>Before:</p>
    <img src="https://user-images.githubusercontent.com/94259578/211197053-e3d8bbd7-e153-43bd-b741-044c921a4719.png" height="440px"/>
</td><td>
    <p>After:</p>
    <img src="https://user-images.githubusercontent.com/94259578/211197063-285e9b15-74ce-4e55-8722-5e756867ddc9.png" height="440px"/>
</td></tr></table>
