### PR TITLE
fix: update api endpoints information

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -17,81 +17,90 @@ app.get('/', (ctx) =>
 	ctx.json([
 		{
 			endpoint: '/leaderboard',
-			description: 'Returns Kings League leaderboard',
+			description: 'Returns the Kings League leaderboard',
 			parameters: [
 				{
 					name: 'team',
 					endpoint: '/leaderboard/:teamId',
-					description: 'Return Kings League leaderboard info from Team Id'
+					description: 'Return the Kings League leaderboard information for a team by his id'
 				}
 			]
 		},
 		{
 			endpoint: '/teams',
-			description: 'Returns Kings League teams',
+			description: 'Returns all Kings League teams',
 			parameters: [
 				{
 					name: 'id',
 					endpoint: '/teams/:id',
-					description: 'Return Kings League team by id'
+					description: 'Return a Kings League team by his id'
+				},
+				{
+					name: 'player-12',
+					endpoint: '/teams/:id/player-12',
+					description: 'Return the Kings League player 12 for the choosed team'
 				}
 			]
 		},
 		{
 			endpoint: '/presidents',
-			description: 'Returns Kings League presidents',
+			description: 'Returns all Kings League presidents',
 			parameters: [
 				{
 					name: 'id',
 					endpoint: '/presidents/:id',
-					description: 'Return Kings League president by id'
+					description: 'Return a Kings League president by his id'
 				}
 			]
 		},
 		{
 			endpoint: '/coaches',
-			description: 'Returns Kings League coaches',
+			description: 'Returns all Kings League coaches',
 			parameters: [
 				{
 					name: 'teamId',
-					endpoint: '/top-assists/:teamId',
-					description: 'Return Kings League coach of team by id of some'
+					endpoint: '/coaches/:teamId',
+					description: 'Return a Kings League coach by his team id'
 				}
 			]
 		},
 		{
+			endpoint: '/top-statistics',
+			description: 'Returns the top statistics of the Kings League',
+		},
+		{
 			endpoint: '/top-assists',
-			description: 'Returns Kings League Top Assists',
+			description: 'Returns all Kings League Top Assists',
 			parameters: [
 				{
 					name: 'rank',
 					endpoint: '/top-assists/:rank',
-					description: 'Return Kings League top assister by rank'
+					description: 'Return a Kings League top assister by his rank'
 				}
 			]
 		},
 		{
 			endpoint: '/top-scorers',
-			description: 'Returns Kings League Top Scorers',
+			description: 'Returns all Kings League Top Scorers',
 			parameters: [
 				{
 					name: 'rank',
 					endpoint: '/top-scorers/:rank',
-					description: 'Return Kings League top scorer by rank'
+					description: 'Return a Kings League top scorer by his rank'
 				}
 			]
 		},
 		{
 			endpoint: '/mvp',
-			description: 'Returns Kings League Most Valuable Players'
+			description: 'Returns all Kings League Most Valuable Players'
 		},
 		{
 			endpoint: '/schedule',
-			description: 'Returns Kings League match schedule and the final score of played games.'
+			description: 'Returns the schedule of all Kings League matches and the final score of each match played'
 		},
 		{
 			endpoint: '/players-12',
-			description: 'Returns Kings League Players Twelve'
+			description: 'Returns all Kings League Players Twelve'
 		}
 	])
 )

--- a/api/index.js
+++ b/api/index.js
@@ -37,8 +37,8 @@ app.get('/', (ctx) =>
 				},
 				{
 					name: 'player-12',
-					endpoint: '/teams/:id/player-12',
-					description: 'Return the Kings League player 12 for the choosed team'
+					endpoint: '/teams/:id/players-12',
+					description: 'Return the Kings League players 12 for the choosed team'
 				}
 			]
 		},


### PR DESCRIPTION
>This PR doesn't involve any change on the logic of the API.

- Updated descriptions to be more informative and accurate.
- Add missing  `/teams/:id/players-12` and `/top-statistics`  endpoints.
- Fixed error in endpoint `/top-assists/:teamId`, as it's actually intended to be `/coaches/:teamId`.