### PR TITLE
style: table teams name add a hover gray color

### DIFF
--- a/src/components/ScheduleRow.astro
+++ b/src/components/ScheduleRow.astro
@@ -23,7 +23,7 @@ if (timestamp && timestamp <= Date.now()) {
 	class='odd:bg-white even:bg-slate-100 flex justify-between group border-y [&>td]:py-2 transition hover:bg-gray-100'
 >
 	<td class='lg:px-2 py-4 border-b-1 flex flex-col md:flex-row justify-end items-center w-full'>
-		<a class='flex justify-start items-center' title={local.name} href={`/team/${local.page}`}>
+		<a class='flex justify-start items-center  hover:text-gray-500' title={local.name} href={`/team/${local.page}`}>
 			{
 				useSmallNames
 ? (
@@ -52,7 +52,7 @@ if (timestamp && timestamp <= Date.now()) {
 
 	<td class='lg:px-2 py-4 border-b-1 flex flex-col md:flex-row justify-start items-center w-full'>
 		<a
-			class='flex justify-end items-center'
+			class='flex justify-end items-center hover:text-gray-500'
 			title={visitant.name}
 			href={`/team/${visitant.page}`}
 			class='order-2 2xl:order-1'


### PR DESCRIPTION
I've added a simple hover style in teams name table
![localname-normal](https://user-images.githubusercontent.com/71975008/211423343-e8a5082b-0640-4c9e-aedb-b1a1bab7851d.png)
![localname-hover](https://user-images.githubusercontent.com/71975008/211423357-2b8e3e11-dc97-479a-a2d3-96cd05ca4169.png)

To make it a little clear that it is clickable.