### PR TITLE
Se arregla el menu de navegacion de la pagina de estadisticas

### DIFF
--- a/src/pages/estadisticas/clasificacion/index.astro
+++ b/src/pages/estadisticas/clasificacion/index.astro
@@ -16,7 +16,7 @@ const { mvp, topScorer, topAssister } = await getFirstPlayersStatistics()
 	<Container>
 		<FloatingBoxContainer>
 			<TabsStatistics />
-			<div class='grid grid-cols-3 gap-y-10 gap-x-5 w-full my-4'>
+			<div class={`grid grid-cols-3 gap-y-10 gap-x-5 w-full mb-4 ${mvp ? 'mt-4 lg:mt-24' : 'mt-4'}`}>
 				{
 					mvp && (
 						<PlayerPrizeCard


### PR DESCRIPTION
Buenos dias,

Se ha modificado el css de el contenedor de la imágenes para que en pantallas a partir de escritorio y, si hay mvp, tenga más margin top con el menú de navegación.

El resultado es este:

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/56631428/211544311-0bff97a9-8f7e-4768-a39a-4d6d02d723d2.png">


Issue #292.

Un saludo, muchas gracias