### PR TITLE
Style: Responsive styles on teams cards from team page

### DIFF
--- a/src/pages/team/[teamId].astro
+++ b/src/pages/team/[teamId].astro
@@ -124,7 +124,7 @@ export async function getStaticPaths() {
 
 		<Container>
 			<div
-				class='overflow-hidden bg-white p-20 pt-5 shadow-xl rounded -mt-10 z-10 mb-40'
+				class='overflow-hidden bg-white p-8 sm:p-20 pt-5 shadow-xl rounded -mt-10 z-10 mb-40'
 				style={`--tw-gradient-from: ${color}`}
 			>
 				<h2 class='font-title text-5xl text-black text-center py-10'>Todos los equipos</h2>


### PR DESCRIPTION
Small style change.
Now on smaller devices, team cards now display larger on team pages.

Before (375 x 667):
![imagen](https://user-images.githubusercontent.com/6018527/211679274-0ede0920-3355-43d6-9b23-4e20283467ee.png)

After (375 x 667): 
![imagen](https://user-images.githubusercontent.com/6018527/211679378-9c42b318-9c07-4082-9515-6f18ef1755e7.png)

