### PR TITLE
Add new route for teams endpoint

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -51,6 +51,7 @@ The available endpoints are:
  - GET `/teams`: Returns all the teams in the Kings League.
  - GET `/teams/:id`: Returns a Kings League team.
  - GET `/teams/:id/player-12`: Returns a player 12 from a Kings League team.
+ - GET `/teams/:id/players/:playerId`: Returns a player from a Kings League team.
  - GET `/presidents`: Returns all Kings League presidents.
  - GET `/presidents/:id`: Returns a president of a Kings League team.
  - GET `/coaches`: Returns all the coaches in the Kings League.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Los endpoints disponibles son:
 - GET `/teams`: Devuelve todos los equipos de la Kings League.
 - GET `/teams/:id`: Devuelve un equipo de la Kings League.
 - GET `/teams/:id/player-12`: Devuelve un jugador 12 de un equipo de la Kings League.
+- GET `/teams/:id/players/:playerId`: Devuelve un jugador de un equipo de la Kings League.
 - GET `/presidents`: Devuelve todos los presidentes de la Kings League.
 - GET `/presidents/:id`: Devuelve un presidente de un equipo de la Kings League.
 - GET `/coaches`: Devuelve todos los entrenadores de la Kings League.

--- a/api/index.js
+++ b/api/index.js
@@ -39,6 +39,11 @@ app.get('/', (ctx) =>
 					name: 'player-12',
 					endpoint: '/teams/:id/players-12',
 					description: 'Return the Kings League players 12 for the choosed team'
+				},
+				{
+					name: 'playerId',
+					endpoint: '/teams/:id/players/:playerId',
+					description: 'Returns a player from a Kings League team.'
 				}
 			]
 		},
@@ -170,6 +175,17 @@ app.get('/teams/:id', (ctx) => {
 })
 
 app.get('/schedule', (ctx) => ctx.json(schedule))
+
+app.get('/teams/:id/players/:playerId', (ctx) => {
+	const teamId = ctx.req.param('id')
+	const playerId = ctx.req.param('playerId')
+	const foundTeam = teams.find((team) => team.id === teamId)
+	if (!foundTeam) return ctx.json({ message: 'Team not found' }, 404)
+	const foundPlayer = foundTeam.players.find((player) => player.id === `${teamId}-${playerId}`)
+	return foundPlayer
+		? ctx.json(foundPlayer)
+		: ctx.json({ message: `Players for team ${teamId} not found` }, 404)
+})
 
 app.get('/teams/:id/players-12', (ctx) => {
 	const id = ctx.req.param('id')


### PR DESCRIPTION
# What?
- Add route to search for a player by his id of a certain team.
-- Example : `/teams/pio-fc/players/1`