### PR TITLE
add background header in tables matches (/calendario page)

### DIFF
--- a/src/pages/calendario/index.astro
+++ b/src/pages/calendario/index.astro
@@ -17,13 +17,16 @@ const schedule = await getSchedule()
 		>
 			<div class='max-w-5xl mx-auto my-4'>
 				{
-					schedule.map((day) => {
+					schedule.map((day, index) => {
 						return (
 							<section>
 								<table class='w-full table-fixed mb-16'>
 									<thead class='border-b-2 border-b-black'>
 										<tr>
-											<td class='text-[25px] text-black p-2'>{day.date}</td>
+											<td class='text-white py-2 px-4 bg-black text-center rounded-t-lg'>
+												<p class='text-[25px]'>{day.date}</p>
+												<p class='font-semibold'>Jornada {index + 1}</p>
+											</td>
 										</tr>
 									</thead>
 									<tbody>


### PR DESCRIPTION
Before:

![Screenshot_2023-01-10_20-22-54](https://user-images.githubusercontent.com/38303370/211703349-bfff47db-77c5-4078-8ffd-3b43aa9d2bd4.png)

![Screenshot_2023-01-10_20-23-43](https://user-images.githubusercontent.com/38303370/211703346-25a6aee2-2b85-4102-897a-fe0ce0abd87c.png)

After:

![Screenshot_2023-01-10_20-27-42](https://user-images.githubusercontent.com/38303370/211703968-820ac0f8-be45-4d35-93ec-fd338821560a.png)

![Screenshot_2023-01-10_20-28-27](https://user-images.githubusercontent.com/38303370/211703971-2c82f313-5753-4ffb-b961-21dae9f283ca.png)
