### PR TITLE
Fix: Remove `/plublic` prefix on twelve players page

### DIFF
--- a/src/pages/jugador-12/index.astro
+++ b/src/pages/jugador-12/index.astro
@@ -28,7 +28,7 @@ const playersTwelve = await getAllPlayersTwelve()
 								<div class='flex items-start'>
 									<img
 										class='aspect-[224/315] w-56'
-										src={`/public/teams/players/${image}`}
+										src={`/teams/players/${image}`}
 										alt={firstName}
 									/>
 									<div class='mt-5 bg-[#27272794] p-3 rounded-tl-lg rounded-bl-lg w-full'>


### PR DESCRIPTION
Fix #315.

Before: 

![Twelve players page before the change](https://user-images.githubusercontent.com/94259578/211849014-71bf88c4-d022-41c3-8961-a6eb16c9a37d.png)

After: 

![Twelve players page after the change](https://user-images.githubusercontent.com/94259578/211849208-ffc5ff03-98e5-48e3-aba1-5f2e0d75e129.png)

