### PR TITLE
Fix: Update schedule scraper selectors due to page changes

### DIFF
--- a/db/schedule.json
+++ b/db/schedule.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "1 de Enero de 2023",
+    "date": "01/01/2023",
     "matches": [
       {
         "timestamp": 1672581600000,
@@ -107,7 +107,7 @@
     ]
   },
   {
-    "date": "8 de Enero de 2023",
+    "date": "08/01/2023",
     "matches": [
       {
         "timestamp": 1673186400000,
@@ -209,16 +209,16 @@
             "shortName": "SAI"
           }
         ],
-        "score": "(2)1 – 1(3)"
+        "score": "(2) 1 – 1 (3)"
       }
     ]
   },
   {
-    "date": "15 de Enero de 2023",
+    "date": "15/01/2023",
     "matches": [
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673791200000,
+        "hour": "16:00",
         "teams": [
           {
             "id": "jijantes",
@@ -234,8 +234,8 @@
         "score": "0 – 0"
       },
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673794800000,
+        "hour": "17:00",
         "teams": [
           {
             "id": "rayo-barcelona",
@@ -251,8 +251,8 @@
         "score": "0 – 0"
       },
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673798400000,
+        "hour": "18:00",
         "teams": [
           {
             "id": "saiyans-fc",
@@ -268,8 +268,8 @@
         "score": "0 – 0"
       },
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673802000000,
+        "hour": "19:00",
         "teams": [
           {
             "id": "kunisports",
@@ -285,8 +285,8 @@
         "score": "0 – 0"
       },
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673805600000,
+        "hour": "20:00",
         "teams": [
           {
             "id": "los-troncos",
@@ -302,8 +302,8 @@
         "score": "0 – 0"
       },
       {
-        "timestamp": null,
-        "hour": null,
+        "timestamp": 1673809200000,
+        "hour": "21:00",
         "teams": [
           {
             "id": "el-barrio",
@@ -321,7 +321,7 @@
     ]
   },
   {
-    "date": "22 de Enero de 2023",
+    "date": "22/01/2023",
     "matches": [
       {
         "timestamp": null,
@@ -348,524 +348,6 @@
             "id": "aniquiladores",
             "name": "Aniquiladores FC",
             "shortName": "ANI"
-          },
-          {
-            "id": "saiyans-fc",
-            "name": "Saiyans FC",
-            "shortName": "SAI"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "xbuyer",
-            "name": "XBUYER TEAM",
-            "shortName": "XBU"
-          },
-          {
-            "id": "jijantes",
-            "name": "Jijantes FC",
-            "shortName": "JFC"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "porcinos-fc",
-            "name": "Porcinos FC",
-            "shortName": "POR"
-          },
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "pio",
-            "name": "PIO FC",
-            "shortName": "PIO"
-          },
-          {
-            "id": "kunisports",
-            "name": "Kunisports",
-            "shortName": "KNS"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "ultimate-mostoles",
-            "name": "Ultimate Móstoles",
-            "shortName": "ULT"
-          },
-          {
-            "id": "los-troncos",
-            "name": "Los Troncos FC",
-            "shortName": "TFC"
-          }
-        ],
-        "score": "0 – 0"
-      }
-    ]
-  },
-  {
-    "date": "5 de Febrero de 2023",
-    "matches": [
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "xbuyer",
-            "name": "XBUYER TEAM",
-            "shortName": "XBU"
-          },
-          {
-            "id": "1k",
-            "name": "1K FC",
-            "shortName": "1K"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "kunisports",
-            "name": "Kunisports",
-            "shortName": "KNS"
-          },
-          {
-            "id": "ultimate-mostoles",
-            "name": "Ultimate Móstoles",
-            "shortName": "ULT"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
-          },
-          {
-            "id": "pio",
-            "name": "PIO FC",
-            "shortName": "PIO"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "saiyans-fc",
-            "name": "Saiyans FC",
-            "shortName": "SAI"
-          },
-          {
-            "id": "el-barrio",
-            "name": "El Barrio",
-            "shortName": "ELB"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "los-troncos",
-            "name": "Los Troncos FC",
-            "shortName": "TFC"
-          },
-          {
-            "id": "aniquiladores",
-            "name": "Aniquiladores FC",
-            "shortName": "ANI"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "jijantes",
-            "name": "Jijantes FC",
-            "shortName": "JFC"
-          },
-          {
-            "id": "porcinos-fc",
-            "name": "Porcinos FC",
-            "shortName": "POR"
-          }
-        ],
-        "score": "0 – 0"
-      }
-    ]
-  },
-  {
-    "date": "12 de Febrero de 2023",
-    "matches": [
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "1k",
-            "name": "1K FC",
-            "shortName": "1K"
-          },
-          {
-            "id": "saiyans-fc",
-            "name": "Saiyans FC",
-            "shortName": "SAI"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "aniquiladores",
-            "name": "Aniquiladores FC",
-            "shortName": "ANI"
-          },
-          {
-            "id": "kunisports",
-            "name": "Kunisports",
-            "shortName": "KNS"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "el-barrio",
-            "name": "El Barrio",
-            "shortName": "ELB"
-          },
-          {
-            "id": "los-troncos",
-            "name": "Los Troncos FC",
-            "shortName": "TFC"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "porcinos-fc",
-            "name": "Porcinos FC",
-            "shortName": "POR"
-          },
-          {
-            "id": "xbuyer",
-            "name": "XBUYER TEAM",
-            "shortName": "XBU"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "pio",
-            "name": "PIO FC",
-            "shortName": "PIO"
-          },
-          {
-            "id": "jijantes",
-            "name": "Jijantes FC",
-            "shortName": "JFC"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "ultimate-mostoles",
-            "name": "Ultimate Móstoles",
-            "shortName": "ULT"
-          },
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
-          }
-        ],
-        "score": "0 – 0"
-      }
-    ]
-  },
-  {
-    "date": "19 de Febrero de 2023",
-    "matches": [
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "xbuyer",
-            "name": "XBUYER TEAM",
-            "shortName": "XBU"
-          },
-          {
-            "id": "pio",
-            "name": "PIO FC",
-            "shortName": "PIO"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "kunisports",
-            "name": "Kunisports",
-            "shortName": "KNS"
-          },
-          {
-            "id": "el-barrio",
-            "name": "El Barrio",
-            "shortName": "ELB"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "porcinos-fc",
-            "name": "Porcinos FC",
-            "shortName": "POR"
-          },
-          {
-            "id": "1k",
-            "name": "1K FC",
-            "shortName": "1K"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
-          },
-          {
-            "id": "aniquiladores",
-            "name": "Aniquiladores FC",
-            "shortName": "ANI"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "los-troncos",
-            "name": "Los Troncos FC",
-            "shortName": "TFC"
-          },
-          {
-            "id": "saiyans-fc",
-            "name": "Saiyans FC",
-            "shortName": "SAI"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "jijantes",
-            "name": "Jijantes FC",
-            "shortName": "JFC"
-          },
-          {
-            "id": "ultimate-mostoles",
-            "name": "Ultimate Móstoles",
-            "shortName": "ULT"
-          }
-        ],
-        "score": "0 – 0"
-      }
-    ]
-  },
-  {
-    "date": "26 de Febrero de 2023",
-    "matches": [
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "1k",
-            "name": "1K FC",
-            "shortName": "1K"
-          },
-          {
-            "id": "los-troncos",
-            "name": "Los Troncos FC",
-            "shortName": "TFC"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "el-barrio",
-            "name": "El Barrio",
-            "shortName": "ELB"
-          },
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "saiyans-fc",
-            "name": "Saiyans FC",
-            "shortName": "SAI"
-          },
-          {
-            "id": "kunisports",
-            "name": "Kunisports",
-            "shortName": "KNS"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "aniquiladores",
-            "name": "Aniquiladores FC",
-            "shortName": "ANI"
-          },
-          {
-            "id": "jijantes",
-            "name": "Jijantes FC",
-            "shortName": "JFC"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "pio",
-            "name": "PIO FC",
-            "shortName": "PIO"
-          },
-          {
-            "id": "porcinos-fc",
-            "name": "Porcinos FC",
-            "shortName": "POR"
-          }
-        ],
-        "score": "0 – 0"
-      },
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "ultimate-mostoles",
-            "name": "Ultimate Móstoles",
-            "shortName": "ULT"
-          },
-          {
-            "id": "xbuyer",
-            "name": "XBUYER TEAM",
-            "shortName": "XBU"
-          }
-        ],
-        "score": "0 – 0"
-      }
-    ]
-  },
-  {
-    "date": "5 de Marzo de 2023",
-    "matches": [
-      {
-        "timestamp": null,
-        "hour": null,
-        "teams": [
-          {
-            "id": "rayo-barcelona",
-            "name": "Rayo de Barcelona",
-            "shortName": "RDB"
           },
           {
             "id": "saiyans-fc",
@@ -885,6 +367,524 @@
             "shortName": "XBU"
           },
           {
+            "id": "jijantes",
+            "name": "Jijantes FC",
+            "shortName": "JFC"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "porcinos-fc",
+            "name": "Porcinos FC",
+            "shortName": "POR"
+          },
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "pio",
+            "name": "PIO FC",
+            "shortName": "PIO"
+          },
+          {
+            "id": "kunisports",
+            "name": "Kunisports",
+            "shortName": "KNS"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "ultimate-mostoles",
+            "name": "Ultimate Móstoles",
+            "shortName": "ULT"
+          },
+          {
+            "id": "los-troncos",
+            "name": "Los Troncos FC",
+            "shortName": "TFC"
+          }
+        ],
+        "score": "0 – 0"
+      }
+    ]
+  },
+  {
+    "date": "05/02/2023",
+    "matches": [
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "xbuyer",
+            "name": "XBUYER TEAM",
+            "shortName": "XBU"
+          },
+          {
+            "id": "1k",
+            "name": "1K FC",
+            "shortName": "1K"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "kunisports",
+            "name": "Kunisports",
+            "shortName": "KNS"
+          },
+          {
+            "id": "ultimate-mostoles",
+            "name": "Ultimate Móstoles",
+            "shortName": "ULT"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          },
+          {
+            "id": "pio",
+            "name": "PIO FC",
+            "shortName": "PIO"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "saiyans-fc",
+            "name": "Saiyans FC",
+            "shortName": "SAI"
+          },
+          {
+            "id": "el-barrio",
+            "name": "El Barrio",
+            "shortName": "ELB"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "los-troncos",
+            "name": "Los Troncos FC",
+            "shortName": "TFC"
+          },
+          {
+            "id": "aniquiladores",
+            "name": "Aniquiladores FC",
+            "shortName": "ANI"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "jijantes",
+            "name": "Jijantes FC",
+            "shortName": "JFC"
+          },
+          {
+            "id": "porcinos-fc",
+            "name": "Porcinos FC",
+            "shortName": "POR"
+          }
+        ],
+        "score": "0 – 0"
+      }
+    ]
+  },
+  {
+    "date": "12/02/2023",
+    "matches": [
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "1k",
+            "name": "1K FC",
+            "shortName": "1K"
+          },
+          {
+            "id": "saiyans-fc",
+            "name": "Saiyans FC",
+            "shortName": "SAI"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "aniquiladores",
+            "name": "Aniquiladores FC",
+            "shortName": "ANI"
+          },
+          {
+            "id": "kunisports",
+            "name": "Kunisports",
+            "shortName": "KNS"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "el-barrio",
+            "name": "El Barrio",
+            "shortName": "ELB"
+          },
+          {
+            "id": "los-troncos",
+            "name": "Los Troncos FC",
+            "shortName": "TFC"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "porcinos-fc",
+            "name": "Porcinos FC",
+            "shortName": "POR"
+          },
+          {
+            "id": "xbuyer",
+            "name": "XBUYER TEAM",
+            "shortName": "XBU"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "pio",
+            "name": "PIO FC",
+            "shortName": "PIO"
+          },
+          {
+            "id": "jijantes",
+            "name": "Jijantes FC",
+            "shortName": "JFC"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "ultimate-mostoles",
+            "name": "Ultimate Móstoles",
+            "shortName": "ULT"
+          },
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          }
+        ],
+        "score": "0 – 0"
+      }
+    ]
+  },
+  {
+    "date": "19/02/2023",
+    "matches": [
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "xbuyer",
+            "name": "XBUYER TEAM",
+            "shortName": "XBU"
+          },
+          {
+            "id": "pio",
+            "name": "PIO FC",
+            "shortName": "PIO"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "kunisports",
+            "name": "Kunisports",
+            "shortName": "KNS"
+          },
+          {
+            "id": "el-barrio",
+            "name": "El Barrio",
+            "shortName": "ELB"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "porcinos-fc",
+            "name": "Porcinos FC",
+            "shortName": "POR"
+          },
+          {
+            "id": "1k",
+            "name": "1K FC",
+            "shortName": "1K"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          },
+          {
+            "id": "aniquiladores",
+            "name": "Aniquiladores FC",
+            "shortName": "ANI"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "los-troncos",
+            "name": "Los Troncos FC",
+            "shortName": "TFC"
+          },
+          {
+            "id": "saiyans-fc",
+            "name": "Saiyans FC",
+            "shortName": "SAI"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "jijantes",
+            "name": "Jijantes FC",
+            "shortName": "JFC"
+          },
+          {
+            "id": "ultimate-mostoles",
+            "name": "Ultimate Móstoles",
+            "shortName": "ULT"
+          }
+        ],
+        "score": "0 – 0"
+      }
+    ]
+  },
+  {
+    "date": "26/02/2023",
+    "matches": [
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "1k",
+            "name": "1K FC",
+            "shortName": "1K"
+          },
+          {
+            "id": "los-troncos",
+            "name": "Los Troncos FC",
+            "shortName": "TFC"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "el-barrio",
+            "name": "El Barrio",
+            "shortName": "ELB"
+          },
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "saiyans-fc",
+            "name": "Saiyans FC",
+            "shortName": "SAI"
+          },
+          {
+            "id": "kunisports",
+            "name": "Kunisports",
+            "shortName": "KNS"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "aniquiladores",
+            "name": "Aniquiladores FC",
+            "shortName": "ANI"
+          },
+          {
+            "id": "jijantes",
+            "name": "Jijantes FC",
+            "shortName": "JFC"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "pio",
+            "name": "PIO FC",
+            "shortName": "PIO"
+          },
+          {
+            "id": "porcinos-fc",
+            "name": "Porcinos FC",
+            "shortName": "POR"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "ultimate-mostoles",
+            "name": "Ultimate Móstoles",
+            "shortName": "ULT"
+          },
+          {
+            "id": "xbuyer",
+            "name": "XBUYER TEAM",
+            "shortName": "XBU"
+          }
+        ],
+        "score": "0 – 0"
+      }
+    ]
+  },
+  {
+    "date": "05/03/2023",
+    "matches": [
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "rayo-barcelona",
+            "name": "Rayo de Barcelona",
+            "shortName": "RDB"
+          },
+          {
+            "id": "saiyans-fc",
+            "name": "Saiyans FC",
+            "shortName": "SAI"
+          }
+        ],
+        "score": "0 – 0"
+      },
+      {
+        "timestamp": null,
+        "hour": null,
+        "teams": [
+          {
+            "id": "xbuyer",
+            "name": "XBUYER TEAM",
+            "shortName": "XBU"
+          },
+          {
             "id": "aniquiladores",
             "name": "Aniquiladores FC",
             "shortName": "ANI"
@@ -963,7 +963,7 @@
     ]
   },
   {
-    "date": "12 de Marzo de 2023",
+    "date": "12/03/2023",
     "matches": [
       {
         "timestamp": null,
@@ -1070,7 +1070,7 @@
     ]
   },
   {
-    "date": "19 de Marzo de 2023",
+    "date": "19/03/2023",
     "matches": [
       {
         "timestamp": null,

--- a/scraping/schedule.js
+++ b/scraping/schedule.js
@@ -11,21 +11,6 @@ const SELECTORS = {
 	scores: '.fs-table-text_8'
 }
 
-const MONTHS = {
-	ENERO: 1,
-	FEBRERO: 2,
-	MARZO: 3,
-	ABRIL: 4,
-	MAYO: 5,
-	JUNIO: 6,
-	JULIO: 7,
-	AGOSTO: 8,
-	SEPTIEMBRE: 9,
-	OCTUBRE: 10,
-	NOVIEMBRE: 11,
-	DICIEMBRE: 12
-}
-
 const MAPS = {
 	'el-bbarrio': 'el-barrio',
 	'jijantes-fc': 'jijantes',
@@ -60,10 +45,9 @@ export async function getSchedule($) {
 		const $day = $(day)
 
 		const dateRaw = $day.find(SELECTORS.date).text()
-		const date = cleanText(dateRaw)
-
-		const [dayNumber, textMonth, yearNumber] = date.split(' de ')
-		const monthNumber = MONTHS[textMonth.toUpperCase()]
+		const dateAndLeagueDay = cleanText(dateRaw)
+		const date = dateAndLeagueDay.split('–')[1].trim() // 01/01/2023
+		const [dayNumber, monthNumber, yearNumber] = date.split('/')
 		const prefixDate = `${yearNumber}-${monthNumber}-${dayNumber}`
 
 		const $locals = $day.find(SELECTORS.locals)


### PR DESCRIPTION
Fix #323.

The schedule page was changed, so, the scraper didn't work as expected. 

Also the hours for the next matches were added: 

Before: 

![image](https://user-images.githubusercontent.com/94259578/212355704-dbbbb71b-216f-4e45-b3e0-321a078db09d.png)

After: 

![image](https://user-images.githubusercontent.com/94259578/212355869-6e617ba8-6b2a-4643-91af-92feb2af301c.png)