### PR TITLE
Feature: Added download svg for player cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "astro": "1.9.1",
     "cheerio": "1.0.0-rc.12",
     "hono": "2.7.1",
+		"html-to-image": "1.11.4",
     "husky": "8.0.3",
     "picocolors": "1.0.0",
     "tailwindcss": "3.2.4"

--- a/public/icons/download-icon.svg
+++ b/public/icons/download-icon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>download</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="icon" fill="#fff" transform="translate(85.333333, 42.666667)">
+            <path d="M312.32,165.76 L285.013333,132.906667 L192,210.56 L192,7.10542736e-15 L149.333333,7.10542736e-15 L149.333333,210.56 L56.32,132.906667 L29.0133333,165.76 L170.666667,283.733333 L312.32,165.76 L312.32,165.76 Z M1.42108547e-14,341.333333 L341.333333,341.333333 L341.333333,384 L1.42108547e-14,384 L1.42108547e-14,341.333333 Z" id="Combined-Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/src/components/PlayerFifaBadge.astro
+++ b/src/components/PlayerFifaBadge.astro
@@ -38,10 +38,38 @@ const levelColors = {
 const color = levelColors[level]
 ---
 
+<script>
+	import { toSvg } from 'html-to-image';
+	
+	const handleDownload = (e) => {
+		const card = e.target.parentElement
+		const container = document.createElement('div')
+		const button = e.target
+		button.style.display = 'none';
+		card.parentElement.insertBefore(container, card)
+		container.appendChild(card)
+		const name = card.querySelectorAll('img')[1]?.alt
+		toSvg(container).then((url) => {
+			container.parentElement.insertBefore(card, container)
+			container.remove()
+			button.style.display = 'block';
+			const a = document.createElement('a');
+			a.href  = url
+			a.download = `${name} Card`
+			document.body.appendChild(a);
+			a.click();
+			a.remove()
+		})
+	}
+	const cards = document.querySelectorAll('article.card button')
+	cards.forEach((card) => card.addEventListener('click', handleDownload))
+</script>
+
 <article
-	class={`${color} w-52 text-center relative rounded-sm m-auto bg-contain bg-no-repeat aspect-[489/787] overflow-hidden col-span-1`}
+	class={`card ${color} w-52 text-center relative rounded-sm m-auto bg-contain bg-no-repeat aspect-[489/787] col-span-1 group`}
 	style={{ backgroundImage: `url("/bg/${level}.png")` }}
 >
+	<button class="absolute right-0 top-0 p-2 bg-gray-800/70 rounded-full opacity-0 transition-all duration-500 ease-in-out group-hover:opacity-100 hover:scale-105"><img class="w-6 h-6 pointer-events-none" src='/icons/download-icon.svg'/></button>
 	<header class='flex pt-9'>
 		<div class='flex flex-col pl-6'>
 			{


### PR DESCRIPTION
I have submitted a pull request that includes a new feature for downloading player card images in SVG format using the html-to-image library. The decision to use SVG format was made to maintain image quality, however, it is also possible to download the images in PNG format (changes on the code), but this may result in a loss of image quality. I apologize for any issues or inconvenience caused by the implementation of this feature. To ensure that the card images would not be cropped when downloaded, I had to take the following steps:

1. placed the card inside a container
2. extracted the url
3. then returned the card back to its original position

By doing this, I was able to download the player card images without any cropping or loss of quality.

This is my first time working with Astro, and I was not entirely familiar with the best practices for adding event listeners. As a result, I used a basic selector by using querySelector and added the listeners that way.

**When hover on player card:**
![1](https://user-images.githubusercontent.com/95143152/212556092-aa708176-80c0-4a2a-99c1-7e4025d5c03c.png)

**If button is clicked:**
![2](https://user-images.githubusercontent.com/95143152/212556095-40f389b5-21ea-468b-b1ee-1a2e2380942c.png)

**Svg saved:**
![3](https://user-images.githubusercontent.com/95143152/212556093-de208951-439d-47a3-b352-62a682a706f9.png)
